### PR TITLE
Add landing page for tobira gateway toolkit

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>tobira - gateway toolkit</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      background: #0d1117;
+      color: #c9d1d9;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .container {
+      max-width: 600px;
+      width: 100%;
+      padding: 2rem;
+      text-align: center;
+    }
+    h1 {
+      font-size: 2.5rem;
+      color: #f0f6fc;
+      margin-bottom: 0.5rem;
+    }
+    .subtitle {
+      font-size: 1.1rem;
+      color: #8b949e;
+      margin-bottom: 2.5rem;
+    }
+    .packages {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .package-card {
+      display: flex;
+      align-items: center;
+      gap: 1rem;
+      padding: 1.25rem 1.5rem;
+      background: #161b22;
+      border: 1px solid #30363d;
+      border-radius: 8px;
+      text-decoration: none;
+      color: inherit;
+      transition: border-color 0.2s, background 0.2s;
+    }
+    .package-card:hover {
+      border-color: #58a6ff;
+      background: #1c2333;
+    }
+    .package-icon {
+      font-size: 1.5rem;
+      width: 2.5rem;
+      flex-shrink: 0;
+    }
+    .package-info {
+      text-align: left;
+    }
+    .package-name {
+      font-size: 1.1rem;
+      font-weight: 600;
+      color: #58a6ff;
+    }
+    .package-registry {
+      font-size: 0.85rem;
+      color: #8b949e;
+      margin-top: 0.25rem;
+    }
+    .github-link {
+      margin-top: 2.5rem;
+    }
+    .github-link a {
+      color: #8b949e;
+      text-decoration: none;
+      font-size: 0.9rem;
+    }
+    .github-link a:hover {
+      color: #58a6ff;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>tobira</h1>
+    <p class="subtitle">gateway toolkit</p>
+    <div class="packages">
+      <a class="package-card" href="https://www.npmjs.com/package/tobira" target="_blank" rel="noopener">
+        <span class="package-icon">📦</span>
+        <div class="package-info">
+          <div class="package-name">tobira</div>
+          <div class="package-registry">npm</div>
+        </div>
+      </a>
+      <a class="package-card" href="https://pypi.org/project/tobira/" target="_blank" rel="noopener">
+        <span class="package-icon">🐍</span>
+        <div class="package-info">
+          <div class="package-name">tobira</div>
+          <div class="package-registry">PyPI</div>
+        </div>
+      </a>
+    </div>
+    <div class="github-link">
+      <a href="https://github.com/piroz/tobira">GitHub</a>
+    </div>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
This PR adds a landing page (`docs/index.html`) that serves as a gateway to the tobira toolkit packages across different package registries.

## Key Changes
- Created a new landing page with a clean, modern design featuring:
  - Centered layout with responsive design
  - Dark theme styling (GitHub-inspired color scheme)
  - Package cards linking to npm and PyPI registries
  - GitHub repository link
  - Hover effects for improved interactivity

## Implementation Details
- Uses semantic HTML5 structure with proper meta tags for viewport and charset
- Implements a self-contained stylesheet with flexbox layout for responsive design
- Provides direct links to:
  - npm package: https://www.npmjs.com/package/tobira
  - PyPI package: https://pypi.org/project/tobira/
  - GitHub repository: https://github.com/piroz/tobira
- Includes accessibility features (proper link attributes with `target="_blank"` and `rel="noopener"`)
