### PR TITLE
Add Japanese character and door emoji to tobira branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# tobira
+# 🚪 tobira (扉)
 
 gateway toolkit
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>tobira - gateway toolkit</title>
+  <title>tobira (扉) - gateway toolkit</title>
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }
     body {
@@ -85,7 +85,7 @@
 </head>
 <body>
   <div class="container">
-    <h1>tobira</h1>
+    <h1>🚪 tobira (扉)</h1>
     <p class="subtitle">gateway toolkit</p>
     <div class="packages">
       <a class="package-card" href="https://www.npmjs.com/package/tobira" target="_blank" rel="noopener">

--- a/js/README.md
+++ b/js/README.md
@@ -1,4 +1,4 @@
-# tobira
+# 🚪 tobira (扉)
 
 gateway toolkit
 

--- a/python/README.md
+++ b/python/README.md
@@ -1,4 +1,4 @@
-# tobira
+# 🚪 tobira (扉)
 
 gateway toolkit
 


### PR DESCRIPTION
## Summary
Updated the tobira project branding across documentation and website to include the Japanese character (扉) meaning "door/gateway" and a door emoji (🚪) for visual consistency and cultural context.

## Changes
- Updated page title in `docs/index.html` to include Japanese character
- Added door emoji and Japanese character to main heading in `docs/index.html`
- Updated primary README.md heading with emoji and Japanese character
- Updated js/README.md heading with emoji and Japanese character
- Updated python/README.md heading with emoji and Japanese character

## Details
The branding enhancement adds:
- 🚪 Door emoji for visual recognition
- (扉) Japanese character, which literally translates to "door" or "gateway" - a fitting reference to the project's gateway toolkit purpose

This creates a more distinctive and culturally meaningful brand identity across all documentation entry points.
