### PR TITLE
feat: add package keywords for npm/PyPI discoverability

### DIFF
--- a/integrations/haraka/package.json
+++ b/integrations/haraka/package.json
@@ -16,9 +16,13 @@
   "license": "MIT",
   "keywords": [
     "haraka",
+    "haraka-plugin",
     "plugin",
     "spam",
-    "tobira"
+    "spam-detection",
+    "email",
+    "tobira",
+    "machine-learning"
   ],
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/js/package.json
+++ b/js/package.json
@@ -16,8 +16,12 @@
   },
   "license": "MIT",
   "keywords": [
-    "gateway",
     "spam",
+    "email",
+    "spam-detection",
+    "machine-learning",
+    "mail-server",
+    "mta",
     "classification"
   ],
   "devDependencies": {

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -9,6 +9,32 @@ description = "tobira - gateway toolkit"
 readme = "README.md"
 license = "MIT"
 requires-python = ">=3.9"
+keywords = [
+    "spam",
+    "email",
+    "spam-detection",
+    "machine-learning",
+    "mail-server",
+    "fasttext",
+    "bert",
+    "mta",
+    "rspamd",
+    "spamassassin",
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: System Administrators",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Communications :: Email :: Filters",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+]
 dependencies = []
 
 [project.optional-dependencies]


### PR DESCRIPTION
- Add keywords and classifiers to python/pyproject.toml for PyPI
- Expand keywords in js/package.json (remove generic "gateway")
- Expand keywords in integrations/haraka/package.json